### PR TITLE
Enable 64‑bit file support

### DIFF
--- a/BUGS
+++ b/BUGS
@@ -1,7 +1,8 @@
 Known Bugs
 ----------
-Can't read *.avi file > 4GiB
-Will be fix. Most Linux system with ext2 filesystem wont allow avi file more than 2GiB anyway.
+Older versions couldn't read *.avi files larger than 4GiB.
+cfourcc now compiles with large file support (-D_FILE_OFFSET_BITS=64) so
+such files are handled correctly.
 
 Other Bugs?
 Probably many, please report it to <mypapit+cfourcc@gmail.com> if it too annoying you.

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #
 
 CC=gcc
-CFLAGS=-O2 -pedantic -ansi -Wall
+CFLAGS=-O2 -pedantic -ansi -Wall -D_FILE_OFFSET_BITS=64
 INSTALL=install
 PREFIX=/usr/local
 

--- a/README
+++ b/README
@@ -24,7 +24,9 @@ FourCC (Four Character Code) is a (rather crude) method to identify codec used t
 For an unofficial list of FourCC/codec out there in the wild, please refer to 'codelist.txt'.
 
 [Installation]
-1) Just type 'make all'. 
+1) Just type 'make all'.
+   The Makefile now compiles with -D_FILE_OFFSET_BITS=64 to enable
+   support for AVI files larger than 4GiB.
 2) be a root user and type 'make install'
 3) use the software as normal user. - refer usage section
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ For more information about this matter please refer to the file COPYING.
 ###Installation
 
 1. Just type 'make all'.
+   The Makefile now enables large file support (-D_FILE_OFFSET_BITS=64)
+   so AVI files larger than 4GiB can be processed.
 2. be a root user and type 'make install'
 3. use the software as normal user. - refer usage section
 

--- a/TODO
+++ b/TODO
@@ -1,1 +1,1 @@
-- fix the 4GiB limitation
+- [done] fix the 4GiB limitation (enabled large file support)

--- a/cfourcc.c
+++ b/cfourcc.c
@@ -21,6 +21,7 @@
     Project's web :  https://github.com/mypapit/cfourcc
 */
 
+#define _GNU_SOURCE
 #include <getopt.h>
 #include <unistd.h>
 #include <stdio.h>
@@ -194,7 +195,7 @@ main (int argc, char *argv[])
 	if (flags & FLAG_DESC)
 	  setDesc (avihdr, ptrdesc);
 
-	fseek (fin, 0, SEEK_SET);
+        fseeko (fin, 0, SEEK_SET);
 	fwrite (avihdr, sizeof (char), AVILEN, fin);
 	fflush (fin);
 	fclose (fin);


### PR DESCRIPTION
## Summary
- support large (>4GiB) AVI files by compiling with `_FILE_OFFSET_BITS=64`
- switch to `fseeko()` for rewriting the file header
- mention large file support in the documentation

## Testing
- `make clean`
- `make all`

------
https://chatgpt.com/codex/tasks/task_e_683fe43a45a0832c90938a352ab123e3